### PR TITLE
Upgrade wasmd version for supporting CosmWasm v1.0.0-beta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor/
 build/
 note.txt
 .chaindata
+.artifacts

--- a/app/app.go
+++ b/app/app.go
@@ -364,7 +364,7 @@ func NewNibiruApp(
 
 	// The last arguments can contain custom message handlers, and custom query handlers,
 	// if we want to allow any custom callbacks
-	supportedFeatures := "staking"
+	supportedFeatures := "iterator,staking,stargate"
 	app.wasmKeeper = wasm.NewKeeper(
 		appCodec,
 		keys[wasm.StoreKey],

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cosmos-gaminghub/nibiru
 go 1.16
 
 require (
-	github.com/CosmWasm/wasmd v0.19.1-0.20211007121137-62e976a55157
+	github.com/CosmWasm/wasmd v0.20.0
 	github.com/cosmos/cosmos-sdk v0.42.10
 	github.com/gogo/protobuf v1.3.3
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -53,11 +53,11 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQcITbvhmL4+C4cKA87NW0tfm3Kl9VXRoPywFg=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/CosmWasm/wasmd v0.16.0/go.mod h1:EmtH0lN3ZlHyU5Sn1VzbZ9guf0BMBSPifzodBcK6d2E=
-github.com/CosmWasm/wasmd v0.19.1-0.20211007121137-62e976a55157 h1:4ZFZ/TxNpSsBaCoT2vNWS2TC72feLvEAwYw5NHh0qT0=
-github.com/CosmWasm/wasmd v0.19.1-0.20211007121137-62e976a55157/go.mod h1:zuZutqwB8XIOzgw1tk6vDFVTGixlP+pPza91i0zl8bQ=
+github.com/CosmWasm/wasmd v0.20.0 h1:5iuazO1EU/fOSgBoKxIFbtS4pRXWgXN+7oVUSulm7XA=
+github.com/CosmWasm/wasmd v0.20.0/go.mod h1:XsG61XO+WTh/001JwW+7jOQRFgpbYNlMZ0ntDyqPAOM=
 github.com/CosmWasm/wasmvm v0.14.0/go.mod h1:Id107qllDJyJjVQQsKMOy2YYF98sqPJ2t+jX1QES40A=
-github.com/CosmWasm/wasmvm v1.0.0-soon2 h1:lwaV55tM+LMWGM0pu18iESEcAQ/PABNsnVQhCng6xJ8=
-github.com/CosmWasm/wasmvm v1.0.0-soon2/go.mod h1:Id107qllDJyJjVQQsKMOy2YYF98sqPJ2t+jX1QES40A=
+github.com/CosmWasm/wasmvm v1.0.0-beta h1:cTBsF0tZ2A54PMlDbBcHmf+P1I7BKxnpTHn9NA06TPg=
+github.com/CosmWasm/wasmvm v1.0.0-beta/go.mod h1:Id107qllDJyJjVQQsKMOy2YYF98sqPJ2t+jX1QES40A=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=


### PR DESCRIPTION
Upgraded wasmd version to latest version which support CosmWasm v1.0.0-beta

## Checklist

- [x] all tests passes
- [x] CosmWasm v1.0.0-beta contract works

## Affected core subsystem(s)
- wasm contracts

## Description of change
- upgraded wasmd version
