### PR TITLE
add mini commission limit for the validator

### DIFF
--- a/app/ante_handler.go
+++ b/app/ante_handler.go
@@ -1,9 +1,12 @@
 package app
 
 import (
+	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	channelkeeper "github.com/cosmos/ibc-go/v2/modules/core/04-channel/keeper"
 	ibcante "github.com/cosmos/ibc-go/v2/modules/core/ante"
 )
@@ -14,6 +17,79 @@ type HandlerOptions struct {
 	ante.HandlerOptions
 
 	IBCChannelkeeper channelkeeper.Keeper
+	Cdc              codec.BinaryCodec
+}
+
+type MinCommissionDecorator struct {
+	cdc codec.BinaryCodec
+}
+
+func NewMinCommissionDecorator(cdc codec.BinaryCodec) MinCommissionDecorator {
+	return MinCommissionDecorator{cdc}
+}
+
+func (min MinCommissionDecorator) AnteHandle(
+	ctx sdk.Context, tx sdk.Tx,
+	simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	msgs := tx.GetMsgs()
+	minCommissionRate := sdk.NewDecWithPrec(5, 2)
+
+	validMsg := func(m sdk.Msg) error {
+		switch msg := m.(type) {
+		case *stakingtypes.MsgCreateValidator:
+			// prevent new validators joining the set with
+			// commission set below 5%
+			c := msg.Commission
+			if c.Rate.LT(minCommissionRate) {
+				return sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "commission can't be lower than 5%")
+			}
+		case *stakingtypes.MsgEditValidator:
+			// if commission rate is nil, it means only
+			// other fields are affected - skip
+			if msg.CommissionRate == nil {
+				break
+			}
+			if msg.CommissionRate.LT(minCommissionRate) {
+				return sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "commission can't be lower than 5%")
+			}
+		}
+
+		return nil
+	}
+
+	validAuthz := func(execMsg *authz.MsgExec) error {
+		for _, v := range execMsg.Msgs {
+			var innerMsg sdk.Msg
+			err := min.cdc.UnpackAny(v, &innerMsg)
+			if err != nil {
+				return sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "cannot unmarshal authz exec msgs")
+			}
+
+			err = validMsg(innerMsg)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	for _, m := range msgs {
+		if msg, ok := m.(*authz.MsgExec); ok {
+			if err := validAuthz(msg); err != nil {
+				return ctx, err
+			}
+			continue
+		}
+
+		// validate normal msgs
+		err = validMsg(m)
+		if err != nil {
+			return ctx, err
+		}
+	}
+
+	return next(ctx, tx, simulate)
 }
 
 func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
@@ -34,6 +110,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 
 	anteDecorators := []sdk.AnteDecorator{
 		ante.NewSetUpContextDecorator(),
+		NewMinCommissionDecorator(options.Cdc),
 		ante.NewRejectExtensionOptionsDecorator(),
 		ante.NewMempoolFeeDecorator(),
 		ante.NewValidateBasicDecorator(),

--- a/app/app.go
+++ b/app/app.go
@@ -522,6 +522,7 @@ func NewNibiruApp(
 				SigGasConsumer:  ante.DefaultSigVerificationGasConsumer,
 			},
 			IBCChannelkeeper: app.IBCKeeper.ChannelKeeper,
+			Cdc:              appCodec,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and review
the requirements below.

Bug fixes and new features should include tests.
-->
Considering other network's situations, it’s better to set minimum commission fee in code at the mainnet launch for the decentralization of the network.

<!-- _Please make sure to review and check all of these items:_ -->
## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] gentx will fail when validator set commission lower than 5%
- [x] edit-validator will fail when validator try to set commission lower than 5% 
- [x]  authz tx with edit-validator/create-validator will fail 

## Affected core subsystem(s)
<!-- Please provide affected other system(s). -->

## Description of change
<!-- Please provide a description of the change here. -->

Add the logic to check msg in `ante_handler.go` 
* * *
